### PR TITLE
Fix missing Metadata-Flavor header

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,4 +1,5 @@
-go: 1.9.2
+go:
+    version: 1.9.2
 verbose: false
 repository:
     path: github.com/banzaicloud/preemption-exporter

--- a/exporter/metadata.go
+++ b/exporter/metadata.go
@@ -21,11 +21,6 @@ type terminationExporter struct {
 	terminationTime      *prometheus.Desc
 }
 
-type PreemptedData struct {
-	Preempted string    `json:"action"`
-	Time      time.Time `json:"time"`
-}
-
 func NewPreemptionExporter(me string) *terminationExporter {
 	netTransport := &http.Transport{
 		Dial: (&net.Dialer{

--- a/exporter/metadata.go
+++ b/exporter/metadata.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"errors"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -39,28 +40,31 @@ func NewPreemptionExporter(me string) *terminationExporter {
 	return &terminationExporter{
 		httpCli:              client,
 		metadataEndpoint:     me,
-		scrapeSuccessful:     prometheus.NewDesc("gcp_instance_metadata_service_available", "Metadata service available", []string{"instance_id"}, nil),
-		terminationIndicator: prometheus.NewDesc("gcp_instance_termination_imminent", "Instance is about to be terminated", []string{"instance_id"}, nil),
-		terminationTime:      prometheus.NewDesc("gcp_instance_termination_in", "Instance will be terminated in", []string{"instance_id"}, nil),
+		scrapeSuccessful:     prometheus.NewDesc("gcp_instance_metadata_service_available", "Metadata service available", []string{"instance_id", "instance_name"}, nil),
+		terminationIndicator: prometheus.NewDesc("gcp_instance_termination_imminent", "Instance is about to be terminated", []string{"instance_id", "instance_name"}, nil),
+		terminationTime:      prometheus.NewDesc("gcp_instance_termination_in", "Instance will be terminated in", []string{"instance_id", "instance_name"}, nil),
 	}
 }
 
-func (c *terminationExporter) get(path string) (string, int, error) {
+func (c *terminationExporter) get(path string) (string, error) {
 	req, err := http.NewRequest("GET", c.metadataEndpoint+path, nil)
 	if err != nil {
-		return "", 0, err
+		return "", err
 	}
 	req.Header.Set("Metadata-Flavor", "Google")
 	resp, err := c.httpCli.Do(req)
 	if err != nil {
-		return "", 0, err
+		return "", err
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", resp.StatusCode, err
+		return "", err
 	}
-	return string(body), resp.StatusCode, nil
+	if resp.StatusCode == http.StatusNotFound {
+		return "", errors.New("endpoint not fount")
+	}
+	return string(body), nil
 }
 
 func (c *terminationExporter) Describe(ch chan<- *prometheus.Desc) {
@@ -72,34 +76,31 @@ func (c *terminationExporter) Describe(ch chan<- *prometheus.Desc) {
 func (c *terminationExporter) Collect(ch chan<- prometheus.Metric) {
 	var preemptedValue float64
 	log.Info("Fetching termination data from metadata-service")
-	instanceID, statusCode, err := c.get("id")
+	instanceID, err := c.get("id")
 	if err != nil {
 		log.Errorf("couldn't parse instance id from metadata: %s", err.Error())
+		ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 0, "none", "none")
 		return
 	}
-	if statusCode == 404 {
-		log.Errorf("couldn't parse instance id from metadata: endpoint not found")
+	instanceName, err := c.get("name")
+	if err != nil {
+		log.Errorf("couldn't parse instance name from metadata: %s", err.Error())
+		ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 0, instanceID, "none")
 		return
 	}
-	preempted, statusCode, err := c.get("preempted")
+	preempted, err := c.get("preempted")
 	if err != nil {
 		log.Errorf("Failed to fetch data from metadata service: %s", err)
-		ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 0, instanceID)
+		ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 0, instanceID, instanceName)
 		return
-	} else {
-		ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 1, instanceID)
-		if statusCode == 404 {
-			log.Debug("/preempted action endpoint not found")
-			ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, 0, "", instanceID)
-			return
-		}
-		log.Infof("instance endpoint available, will be preempted: %v", preempted)
-		if isPreempted, _ := strconv.ParseBool(preempted); isPreempted {
-			preemptedValue = 1.0
-		}
-		ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, preemptedValue, instanceID)
-		uptime, _ := host.Uptime()
-		log.Infof("instance was started at : %v", uptime)
-		ch <- prometheus.MustNewConstMetric(c.terminationTime, prometheus.GaugeValue, float64(uptime), instanceID)
 	}
+	ch <- prometheus.MustNewConstMetric(c.scrapeSuccessful, prometheus.GaugeValue, 1, instanceID, instanceName)
+	log.Infof("instance endpoint available, will be preempted: %v", preempted)
+	if isPreempted, _ := strconv.ParseBool(preempted); isPreempted {
+		preemptedValue = 1.0
+	}
+	ch <- prometheus.MustNewConstMetric(c.terminationIndicator, prometheus.GaugeValue, preemptedValue, instanceID, instanceName)
+	uptime, _ := host.Uptime()
+	log.Infof("instance was started at : %v", uptime)
+	ch <- prometheus.MustNewConstMetric(c.terminationTime, prometheus.GaugeValue, float64(uptime), instanceID, instanceName)
 }

--- a/util/test_server.go
+++ b/util/test_server.go
@@ -18,6 +18,14 @@ func main() {
 		fmt.Fprint(w, "in-12345")
 	})
 
+	http.HandleFunc("/computeMetadata/v1/instance/name", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			http.Error(w, "Missing Metadata-Flavor:Google header", http.StatusForbidden)
+			return
+		}
+		fmt.Fprint(w, "in")
+	})
+
 	http.HandleFunc("/computeMetadata/v1/instance/preempted", func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Metadata-Flavor") != "Google" {
 			http.Error(w, "Missing Metadata-Flavor:Google header", http.StatusForbidden)

--- a/util/test_server.go
+++ b/util/test_server.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"time"
 )
 
 // use this minimal http server to test the exporter locally
@@ -12,10 +11,18 @@ import (
 func main() {
 
 	http.HandleFunc("/computeMetadata/v1/instance/id", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			http.Error(w, "Missing Metadata-Flavor:Google header", http.StatusForbidden)
+			return
+		}
 		fmt.Fprint(w, "in-12345")
 	})
 
 	http.HandleFunc("/computeMetadata/v1/instance/preempted", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			http.Error(w, "Missing Metadata-Flavor:Google header", http.StatusForbidden)
+			return
+		}
 		fmt.Fprint(w, "TRUE")
 	})
 


### PR DESCRIPTION
```
time="2018-12-12T08:03:32Z" level=info msg="Starting preemption-exporter"
time="2018-12-12T08:03:32Z" level=info msg="Starting metric http endpoint on :9189"
time="2018-12-12T08:04:08Z" level=info msg="Fetching termination data from metadata-service"
time="2018-12-12T08:04:08Z" level=info msg="instance endpoint available, will be preempted: <!DOCTYPE html>\n<html lang=en>\n  <meta charset=utf-8>\n  <meta name=viewport content=\"initial-scale=1, minimum-scale=1, width=device-width\">\n  <title>Error 403 (Forbidden)!!1</title>\n  <style>\n    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\n  </style>\n  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n  <p><b>403.</b> <ins>That’s an error.</ins>\n  <p>Your client does not have permission to get URL <code>/computeMetadata/v1/instance//preempted</code> from this server. Missing Metadata-Flavor:Google header. <ins>That’s all we know.</ins>\n"
time="2018-12-12T08:04:08Z" level=info msg="instance was started at : 7711"
panic: inconsistent label cardinality

goroutine 21 [running]:
github.com/banzaicloud/preemption-exporter/vendor/github.com/prometheus/client_golang/prometheus.MustNewConstMetric(0xc420100ee0, 0x2, 0x3ff0000000000000, 0xc4201f1740, 0x2, 0x2, 0x8e6c20, 0xc4201e66c0)
	/go/src/github.com/banzaicloud/preemption-exporter/vendor/github.com/prometheus/client_golang/prometheus/value.go:172 +0xb3
github.com/banzaicloud/preemption-exporter/exporter.(*terminationExporter).Collect(0xc420069cb0, 0xc42013c060)
	/go/src/github.com/banzaicloud/preemption-exporter/exporter/metadata.go:88 +0xa3f
github.com/banzaicloud/preemption-exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func2(0xc42012a060, 0xc42013c060, 0x8e6be0, 0xc420069cb0)
	/go/src/github.com/banzaicloud/preemption-exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:433 +0x61
created by github.com/banzaicloud/preemption-exporter/vendor/github.com/prometheus/client_golang/prometheus.(*Registry).Gather
	/go/src/github.com/banzaicloud/preemption-exporter/vendor/github.com/prometheus/client_golang/prometheus/registry.go:431 +0x2e1
```
